### PR TITLE
Harmonization footer / navbar

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -4,10 +4,8 @@
   align-items: center;
   justify-content: space-between;
   height: 100px;
-  padding: 0px 50px;
+  padding: 0px 16px;
   color: $btn-color;
-  position: fixed;
-  bottom: 0;
   width: 100%
 }
 
@@ -21,7 +19,7 @@
   opacity: 0.6;
   text-decoration: none;
   font-size: 24px;
-  padding: 0px 10px;
+  padding-right: 10px;
 }
 
 .footer-links a:hover {


### PR DESCRIPTION
Harmonization du footer avec la navbar 

- padding right et left
- position : fixed retiré
- hauteur du footer

<img width="1280" alt="Capture d’écran 2020-05-21 à 20 09 20" src="https://user-images.githubusercontent.com/43042737/82591223-523c2480-9b9f-11ea-9f9c-002a06b5bb50.png">
<img width="1280" alt="Capture d’écran 2020-05-21 à 20 09 28" src="https://user-images.githubusercontent.com/43042737/82591227-55cfab80-9b9f-11ea-83a6-5f8d22b21a3f.png">

 